### PR TITLE
Import and re-org to previously validated payload

### DIFF
--- a/tests/engine-api.md
+++ b/tests/engine-api.md
@@ -276,3 +276,16 @@ All test cases described in this document are beginning in a post-Merge world, i
     * Client continues building canonical chain without issues
   
   </details>
+
+* [ ] Import and re-org to previously validated payload
+  <details>
+  <summary>Click for details &#9662;</summary>
+  
+  * `Genesis <- P1 <- P2 <- P3 <- P4`
+  * EL starts with `head: P4, safe: P3, finalized: P2`
+  * `newPayload(P3)`
+    * EL returns `{status: VALID, latestValidHash: P3.blockHash}`
+  * `forkchoiceUpdated(head: P3, safe: P2, finalized: P1)`
+    * EL returns `{status: VALID, latestValidHash: P3.blockHash}`
+  
+  </details>

--- a/tests/engine-api.md
+++ b/tests/engine-api.md
@@ -281,7 +281,7 @@ All test cases described in this document are beginning in a post-Merge world, i
   
   </details>
 
-* [ ] Import and re-org to previously validated payload
+* [x] [[Hive](https://github.com/ethereum/hive/blob/ee8d44878b25fa3dec59e2536977af8a44b345dd/simulators/ethereum/engine/enginetests.go#L1091)] Import and re-org to previously validated payload
   <details>
   <summary>Click for details &#9662;</summary>
 


### PR DESCRIPTION
Adds the following scenario:
* `Genesis <- P1 <- P2 <- P3 <- P4`
* EL starts with `head: P4, safe: P3, finalized: P2`
* `newPayload(P3)`
    * EL returns `{status: VALID, latestValidHash: P3.blockHash}`
* `forkchoiceUpdated(head: P3, safe: P2, finalized: P1)`
    * EL returns `{status: VALID, latestValidHash: P3.blockHash}`

cc @marioevz 