### PR TITLE
Add Test Cases from ethereum/hive/pull/613

### DIFF
--- a/tests/engine-api.md
+++ b/tests/engine-api.md
@@ -192,7 +192,7 @@ All test cases described in this document are beginning in a post-Merge world, i
   
   </details>
 
-* [ ] Update finalized and safe block on canonical chain
+* [x] [[Hive](https://github.com/ethereum/hive/pull/613)] Update finalized and safe block on canonical chain
   <details>
   <summary>Click for details</summary>
   
@@ -207,7 +207,7 @@ All test cases described in this document are beginning in a post-Merge world, i
   
   </details>
 
-* [ ] Update safe block on a *side* chain
+* [x] [[Hive](https://github.com/ethereum/hive/pull/613)] Update safe block on a *side* chain
   <details>
   <summary>Click for details</summary>
   

--- a/tests/transition.md
+++ b/tests/transition.md
@@ -509,7 +509,7 @@ All test cases described in this document are beginning in a pre-Merge world and
   
   </details>
 
-* [[Hive](https://github.com/ethereum/hive/pull/613)] Stop processing gossiped PoW blocks
+* [x] [[Hive](https://github.com/ethereum/hive/pull/613)] Stop processing gossiped PoW blocks
   <details>
   <summary>Click for details</summary>
 
@@ -528,7 +528,7 @@ All test cases described in this document are beginning in a pre-Merge world and
   
   </details>
 
-* [[Hive](https://github.com/ethereum/hive/pull/613)] Terminal blocks are gossiped
+* [x] [[Hive](https://github.com/ethereum/hive/pull/613)] Terminal blocks are gossiped
   <details>
   <summary>Click for details</summary>
 
@@ -540,7 +540,7 @@ All test cases described in this document are beginning in a pre-Merge world and
   
   </details>
 
-* [[Hive](https://github.com/ethereum/hive/pull/613)] Build Payload After Multiple Terminal blocks via gossip
+* [x] [[Hive](https://github.com/ethereum/hive/pull/613)] Build Payload After Multiple Terminal blocks via gossip
   <details>
   <summary>Click for details</summary>
 

--- a/tests/transition.md
+++ b/tests/transition.md
@@ -509,7 +509,7 @@ All test cases described in this document are beginning in a pre-Merge world and
   
   </details>
 
-* [ ] Stop processing gossiped PoW blocks
+* [[Hive](https://github.com/ethereum/hive/pull/613)] Stop processing gossiped PoW blocks
   <details>
   <summary>Click for details</summary>
 
@@ -528,7 +528,7 @@ All test cases described in this document are beginning in a pre-Merge world and
   
   </details>
 
-* [ ] Terminal blocks are gossiped
+* [[Hive](https://github.com/ethereum/hive/pull/613)] Terminal blocks are gossiped
   <details>
   <summary>Click for details</summary>
 
@@ -537,6 +537,17 @@ All test cases described in this document are beginning in a pre-Merge world and
     * Head of `EL2` client points to `TB`
   * `PoW` client gossips a descendant of `TB`
     * Head of `EL2` client points to `TB`
+  
+  </details>
+
+* [[Hive](https://github.com/ethereum/hive/pull/613)] Build Payload After Multiple Terminal blocks via gossip
+  <details>
+  <summary>Click for details</summary>
+
+  * Consider `PoW <-> EL` as a PoW client connected to EL client `EL`.
+  * `PoW` client produces and gossips multiple terminal blocks `TB1`, `TB2`, ... `TBN`
+  * `newPayload(TBN)` is sent to `EL`
+    * `EL` immediately returns `{status: VALID, latestValidHash: TBN.BlockHash}`
   
   </details>
 


### PR DESCRIPTION
This PR marks several `transition` and `engine-api` tests as complete because of their implementation in https://github.com/ethereum/hive/pull/613