### PR TITLE
No viable head due to optimistic sync

### DIFF
--- a/tests/engine-api.md
+++ b/tests/engine-api.md
@@ -407,19 +407,26 @@ All test cases described in this document are beginning in a post-Merge world, i
   * `... <- P0 <- P1 <- P2 <- ... <- Pn`
     * `BeaconBlock(P0).slot % SLOTS_PER_EPOCH == 0`
     * `BeaconBlock(P0).slot >= 128` to be far enough from Genesis
-  * CLs (builder and importer) process `BeaconBlock(P0), ..., BeaconBlock(P30)`
+  * CL builder1 and CL importer process `BeaconBlock(P0), ..., BeaconBlock(P10)`
     * EL mock returns `status: VALID`
-  * CL builder
-    * `BeaconBlock(P31)`: EL mock returns `status: VALID`
-    * `BeaconBlock(P32)`: EL mock returns `status: INVALID`
-    * `BeaconBlock(P33)` and onwards: EL mock returns `status: VALID`, `BeaconBlock(P33)` is built atop of `BeaconBlock(P31)`
+  * CL builder1
+    * `BeaconBlock(P11), ..., BeaconBlock(P33)`: EL mock returns `status: VALID`
   * CL importer
-    * `BeaconBlock(P31)`: EL mock returns `status: SYNCING`
-    * `BeaconBlock(P32)`
-      * `newPayload(P32)`: `status: SYNCING`
-      * `forkchoiceUpdated(P32)`: `{status: INVALID, latestValidHash: P31.blockHash}`
+    * `BeaconBlock(P10), ..., BeaconBlock(P32)`: EL mock returns `status: SYNCING`
+    * `BeaconBlock(P33)`
+      * first variation
+        * `newPayload(P33)`: `{status: INVALID, latestValidHash: P10.blockHash}`
+      * second variation
+        * `newPayload(P33)`: `{status: SYNCING}`
+        * `forkChoiceUpdated(P33)`: `{status: INVALID, latestValidHash: P10.blockHash}`
     * Check that the node stays optimistic, i.e. `execution_optimistic` flag in Beacon API responses is `true`
-    * `BeaconBlock(P33)`: EL mock returns `status: VALID`
-    * Check that the node is not optimistic anymore and `BeaconBlock(P33)` is the head
+  * CL builder1 gets shut down
+  * CL builder2 
+    * starts up, peers with CL importer and syncs up to `BeaconBlock(P10)`
+    * `BeaconBlock(P11, slot34), ..., BeaconBlock(Pn, slotN)`: EL mock returns `status: VALID`
+  * CL importer
+    * `BeaconBlock(P11, slot34), ..., BeaconBlock(Pn, slotN)`: EL mock returns `status: VALID`
+    * `slotN` should be high enough for importer to recover from optimistic state, `N >= 96`
+    * Check that the node is not optimistic anymore and `BeaconBlock(Pn, slotN)` is the head
   
   </details>

--- a/tests/engine-api.md
+++ b/tests/engine-api.md
@@ -407,7 +407,7 @@ All test cases described in this document are beginning in a post-Merge world, i
   * `... <- P0 <- P1 <- P2 <- ... <- Pn`
     * `BeaconBlock(P0).slot % SLOTS_PER_EPOCH == 0`
     * `BeaconBlock(P0).slot >= 128` to be far enough from Genesis
-  * CLs (builder and importer) processes `BeaconBlock(P0), ..., BeaconBlock(P30)`
+  * CLs (builder and importer) process `BeaconBlock(P0), ..., BeaconBlock(P30)`
     * EL mock returns `status: VALID`
   * CL builder
     * `BeaconBlock(P31)`: EL mock returns `status: VALID`

--- a/tests/engine-api.md
+++ b/tests/engine-api.md
@@ -397,3 +397,18 @@ All test cases described in this document are beginning in a post-Merge world, i
     * `P` is the head of EL chain
 
   </details>
+
+* [ ] No viable head due to optimistic sync
+  <details>
+  <summary>Click for details</summary>
+  
+  * `... <- P0 <- P1 <- P2 <- ... <- Pn`, `n >= SLOTS_PER_EPOCH`, i.e. `P1 <- ... <- Pn` crosses epoch boundary
+  * `BeaconBlock(P0).slot % SLOTS_PER_EPOCH == 0`, `BeaconBlock(P0)` epoch is at least 2 epochs far from Genesis' epoch
+  * CL imports `BeaconBlock(P0), ..., BeaconBlock(Pn)` block by block
+    * EL mock returns valid to `newPayload(P0)` call
+    * EL mock should start responding `SYNCING` to `newPayload(P1)` and keep return `SYNCING` until `newPayload(P[n-1])`
+    * CL enters optimistic mode since `BeaconBlock(P1)`
+    * EL mock should respond `status: INVALID, latestValidHash: P1.blockHash` to `newPayload(Pn)`
+  * CL stays optimistic, i.e. `execution_optimistic` flag in Beacon API responses is `true`
+  
+  </details>


### PR DESCRIPTION
This test covers scenario outlined in https://github.com/ethereum/consensus-specs/pull/2955#issuecomment-1198282331

The outlined scenario checks only that CL stays optimistic if there are no viable tips.

Ideally, we should also check that CL may recover from the optimistic state without viable tips by importing a viable chain. But creating this scenario seems non-trivial as there should be CL validator that produces a malicious fork of a few blocks length. It can be implemented as follows:
1. Builder produces blocks up to slot 0 block into epoch N+1
2. Importer turns optimistic on 20th block and invalidates all blocks starting from 21st by receiving corresponding LVH value on `newPayload` in 0th slot of epoch N+1
3. Builder realizes that blocks from 21st of epoch N till 0th of epoch N+1 are invalid and continues to build a chain from the 1st slot of epoch N+1 with parent block from 20th slot of epoch N and eventually justifies N+1. Importer gets `VALID` status on each of these new blocks

"Builder realizes that blocks from 21st of epoch N till 0th of epoch N+1 are invalid" is something that I am not sure could be implemented with existing tools cc @marioevz 

cc @potuz @paulhauner @ajsutton @tersec